### PR TITLE
Allow subclass to inherit default exceptions

### DIFF
--- a/lib/batch.rb
+++ b/lib/batch.rb
@@ -33,11 +33,8 @@ class Batch
   # Override this method in children to behave as expected for different types
   # of collections
   def include?(file_name) 
-    include_file = true
-    include_file = !(file_name.start_with? ".")
-    include_file = !(file_name.end_with? ".csv")
-
-    include_file
+    (!(file_name.start_with? ".") &&
+     !(file_name.end_with? ".csv"))
   end
 
   def add_file(file_name, metadata)

--- a/lib/editorial_batch.rb
+++ b/lib/editorial_batch.rb
@@ -2,7 +2,8 @@ require 'batch'
 
 class EditorialBatch < Batch
   def include? file_name
-    allowed_extensions.include? File.extname(file_name)
+    super && 
+      allowed_extensions.include?(File.extname(file_name))
   end
 
   def add_file(file, metadata)


### PR DESCRIPTION
Editorial class was not ignoring dot files properly. This new logic should allow a pattern that chains additional exceptions rather than overriding the method completely.