### PR TITLE
Fail if sources table is missing

### DIFF
--- a/lib/object_photography_batch.rb
+++ b/lib/object_photography_batch.rb
@@ -74,7 +74,11 @@ class ObjectPhotographyBatch < Batch
 
   def load_photostudio_db path
     @database = Sequel.sqlite(database: path)
-    @photography_db = @database[:sources]
+    if @database.table_exists? :sources
+      @photography_db = @database[:sources]
+    else
+      raise RuntimeError.new "Table sources could not be found"
+    end
   end
 
   protected

--- a/spec/object_photography_batch_spec.rb
+++ b/spec/object_photography_batch_spec.rb
@@ -110,4 +110,19 @@ RSpec.describe ObjectPhotographyBatch do
       expect(tiff.metadata[:part_of]).to eq "DVD0919"
     end
   end
+
+  describe "#load_photostudio_db" do
+    let(:batch) { ObjectPhotographyBatch.new }
+    
+    it "initializes the database connection" do
+      batch.load_photostudio_db("spec/fixtures/photo-mock.db")
+      
+      expect(batch.photography_db.class).to eq Sequel::SQLite::Dataset
+    end
+
+    it "throws an error when the table is missing" do
+      expect { batch.load_photostudio_db "spec/fixtures/bad-db-path" }.to raise_error(RuntimeError)
+      File.delete("spec/fixtures/bad-db-path")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@ RSpec.configure do |config|
   config.color = true
   config.add_formatter :documentation
 
-  #config.before(:all) { silence_output }
-  #config.after(:all) { enable_output }
+  config.before(:all) { silence_output }
+  config.after(:all) { enable_output }
 end
 
 def silence_output


### PR DESCRIPTION
If the sources table is not present when you attempt to connect to the database fail immediately instead of letting the error be caught only when doing an update