### PR TITLE
Register properties globally so they appear in CSV

### DIFF
--- a/lib/batch.rb
+++ b/lib/batch.rb
@@ -34,7 +34,7 @@ class Batch
     else
       print "WARNING: Directory name is invalid\n"  
     end
-    print "\n"
+    puts
   end
 
   # Given a file determine if it should be included in the manifest or not.

--- a/lib/object_photography_batch.rb
+++ b/lib/object_photography_batch.rb
@@ -30,6 +30,11 @@ class ObjectPhotographyBatch < Batch
              nil :
              metadata[:date_created].strftime("%Y-%m-%d")
           @files[file].add_attribute(:date_created, date_created)
+          
+          # Need to register the properties so they can be added to the
+          # manifest
+          @properties[:date_created] ||= nil
+          @properties[:source] ||= nil
         end
       end
     end


### PR DESCRIPTION
Only properties which were globally registered were showing up in the batch manifests. This little fix ensures that if you register them they will show up across the board.