### PR TITLE
Remap export field for capture device from source

### DIFF
--- a/lib/object_photography_batch.rb
+++ b/lib/object_photography_batch.rb
@@ -26,7 +26,7 @@ class ObjectPhotographyBatch < Batch
       metadata = PhotostudioRecord.where(accession_master: accession_master,
         dvd: dvd).first
       unless metadata.nil?
-        @files[file].add_attribute(:source, metadata[:source])
+        @files[file].add_attribute(:capture_device, metadata[:source])
 
         date_created = metadata[:date_created].nil? ?
            nil :
@@ -36,7 +36,7 @@ class ObjectPhotographyBatch < Batch
         # Need to register the properties so they can be added to the
         # manifest
         @properties[:date_created] ||= nil
-        @properties[:source] ||= nil
+        @properties[:capture_device] ||= nil
       end
     end
   end

--- a/spec/object_photography_batch_spec.rb
+++ b/spec/object_photography_batch_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ObjectPhotographyBatch do
  
       file = batch.files["2014.12.tif"]
       expect(file.metadata[:part_of]).to eq "DVD0452"
-      expect(file.metadata[:source]).to eq "Topaz"
+      expect(file.metadata[:capture_device]).to eq "Topaz"
       expect(file.metadata[:date_created]).to eq "2005-02-01"
     end
 
@@ -68,7 +68,7 @@ RSpec.describe ObjectPhotographyBatch do
 
       file = batch.files["1992.394.tif"]
       expect(file.metadata[:part_of]).to eq "WIB095"
-      expect(file.metadata[:source]).to eq "CAMERA"
+      expect(file.metadata[:capture_device]).to eq "CAMERA"
       expect(file.metadata[:date_created]).to be_nil
     end
   end


### PR DESCRIPTION
Source is already being used elsewhere so the FITS field capture_device is used instead. Since this is already baked in to the characterization it should work for the short to medium term until an ideal data model can be built.